### PR TITLE
[Proposal] Empower Reducer with State Monad

### DIFF
--- a/Examples/Counter.swift
+++ b/Examples/Counter.swift
@@ -28,8 +28,8 @@ class CounterViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        reducer.addEdge(event: .increment) { $0 + 1 }
-        reducer.addEdge(event: .decrement) { $0 - 1 }
+        reducer.accept(event: .increment) { $0 + 1 }
+        reducer.accept(event: .decrement) { $0 - 1 }
 
         // UI is user feedback
         let feedbackLoop: (ObservableSchedulerContext<State>) -> Observable<Event> = bind(self) { me, state -> Bindings<Event> in

--- a/RxFeedback.xcodeproj/project.pbxproj
+++ b/RxFeedback.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		52D6D9871BEFF229002C0205 /* RxFeedback.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* RxFeedback.framework */; };
+		B443687C1FB73EF7006AF2DF /* Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B443687A1FB73EF6006AF2DF /* Reducer.swift */; };
+		B443687D1FB73EF7006AF2DF /* StateMonad.swift in Sources */ = {isa = PBXBuildFile; fileRef = B443687B1FB73EF7006AF2DF /* StateMonad.swift */; };
 		C80987441EC4882E00EE2C23 /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80987431EC4882E00EE2C23 /* Todo.swift */; };
 		C80987621EC4A28300EE2C23 /* Todo+Plumbing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C809875E1EC49F7400EE2C23 /* Todo+Plumbing.swift */; };
 		C80987631EC4A28E00EE2C23 /* Todo+Lenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = C809875C1EC49F4900EE2C23 /* Todo+Lenses.swift */; };
@@ -269,6 +271,8 @@
 		52D6D9861BEFF229002C0205 /* RxFeedbackTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RxFeedbackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD2FAA261CD0B6D800659CF4 /* RxFeedback.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = RxFeedback.plist; sourceTree = "<group>"; };
 		AD2FAA281CD0B6E100659CF4 /* RxFeedbackTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = RxFeedbackTests.plist; sourceTree = "<group>"; };
+		B443687A1FB73EF6006AF2DF /* Reducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reducer.swift; sourceTree = "<group>"; };
+		B443687B1FB73EF7006AF2DF /* StateMonad.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateMonad.swift; sourceTree = "<group>"; };
 		C8047ABB1F41099F0089721B /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		C80987431EC4882E00EE2C23 /* Todo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Todo.swift; sourceTree = "<group>"; };
 		C80987581EC4916000EE2C23 /* Todo+Feedback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Todo+Feedback.swift"; sourceTree = "<group>"; };
@@ -401,6 +405,8 @@
 		C834A8671EB6794F00E6B15E /* RxFeedback */ = {
 			isa = PBXGroup;
 			children = (
+				B443687A1FB73EF6006AF2DF /* Reducer.swift */,
+				B443687B1FB73EF7006AF2DF /* StateMonad.swift */,
 				C834A8681EB6795F00E6B15E /* ObservableType+RxFeedback.swift */,
 				C89B96241EB6964200BDAB24 /* Feedbacks.swift */,
 				C8996C791F40C5B6004E5D83 /* Deprecations.swift */,
@@ -910,6 +916,8 @@
 			files = (
 				C89B96251EB6964200BDAB24 /* Feedbacks.swift in Sources */,
 				C8996C7A1F40C5B6004E5D83 /* Deprecations.swift in Sources */,
+				B443687C1FB73EF7006AF2DF /* Reducer.swift in Sources */,
+				B443687D1FB73EF7006AF2DF /* StateMonad.swift in Sources */,
 				C834A8691EB6795F00E6B15E /* ObservableType+RxFeedback.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/RxFeedback/ObservableType+RxFeedback.swift
+++ b/Sources/RxFeedback/ObservableType+RxFeedback.swift
@@ -57,10 +57,10 @@ extension ObservableType where E == Any {
     }
 
     public static func system<State, Event>(
-        initialState: State,
-        reducer: Reducer<State, Event>,
-        scheduler: ImmediateSchedulerType,
-        scheduledFeedback: [Feedback<State, Event>]
+            initialState: State,
+            reducer: Reducer<State, Event>,
+            scheduler: ImmediateSchedulerType,
+            scheduledFeedback: Feedback<State, Event>...
         ) -> Observable<State> {
         return system(initialState: initialState, reduce: reducer.reduce, scheduler: scheduler, scheduledFeedback: scheduledFeedback)
     }

--- a/Sources/RxFeedback/ObservableType+RxFeedback.swift
+++ b/Sources/RxFeedback/ObservableType+RxFeedback.swift
@@ -57,6 +57,15 @@ extension ObservableType where E == Any {
     }
 
     public static func system<State, Event>(
+        initialState: State,
+        reducer: Reducer<State, Event>,
+        scheduler: ImmediateSchedulerType,
+        scheduledFeedback: [Feedback<State, Event>]
+        ) -> Observable<State> {
+        return system(initialState: initialState, reduce: reducer.reduce, scheduler: scheduler, scheduledFeedback: scheduledFeedback)
+    }
+
+    public static func system<State, Event>(
             initialState: State,
             reduce: @escaping (State, Event) -> State,
             scheduler: ImmediateSchedulerType,

--- a/Sources/RxFeedback/Reducer.swift
+++ b/Sources/RxFeedback/Reducer.swift
@@ -8,37 +8,33 @@
 
 import Foundation
 
-public class Reducer<State: Equatable, Event> {
+public class Reducer<State: Equatable, Event: Equatable> {
 
     typealias Transition = (Event) -> StateMonad<State>
     private var graph: [Transition] = []
-    private let identity: State
     private let identityMonad: StateMonad<State> = StateMonad { s in return s }
-    
-    public init(defaultState: State) {
-        identity = defaultState
-    }
+
+    public init() {}
 
     public func addEdge(event: Event, transform: @escaping (State) -> State) {
-        let transition: Transition = { event in
+        let transition: Transition = { [unowned self] e in
+            guard e == event else { return self.identityMonad }
             return StateMonad(f: transform)
         }
         graph.append(transition)
     }
 
-    public var reduce: (State, Event) -> State {
-        return { [unowned self] state, event in
-            let monad: StateMonad<State> = self.graph
-                .map { $0(event) }
-                .reduce(self.identityMonad) { lhs, rhs in
-                    return StateMonad { [unowned self] s in
-                        if lhs.run(s: s) != self.identity { return lhs.run(s: s) }
-                        if rhs.run(s: s) != self.identity { return rhs.run(s: s) }
-                        return self.identity
-                    }
+    public lazy var reduce: (State, Event) -> State = { [unowned self] state, event in
+        let monad: StateMonad<State> = self.graph
+            .map { $0(event) }
+            .reduce(self.identityMonad) { lhs, rhs in
+                return StateMonad { s in
+                    if lhs.run(s: s) != state { return lhs.run(s: s) }
+                    if rhs.run(s: s) != state { return rhs.run(s: s) }
+                    return state
                 }
-            return monad.run(s: state)
-        }
+            }
+        return monad.run(s: state)
     }
 
 }

--- a/Sources/RxFeedback/Reducer.swift
+++ b/Sources/RxFeedback/Reducer.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+/**
+ Reducer class that defines transition rules as a set of type (Event) -> StateMonad<State>.
+ */
 public class Reducer<State: Equatable, Event: Equatable> {
 
     typealias Transition = (Event) -> StateMonad<State>
@@ -16,6 +19,12 @@ public class Reducer<State: Equatable, Event: Equatable> {
 
     public init() {}
 
+    /**
+    Accept individual rule.
+
+     - parameter event: event triggers state transformation.
+     - parameter transform: transformation from current state to next state.
+     */
     public func accept(event: Event, transform: @escaping (State) -> State) {
         let transition: Transition = { [unowned self] e in
             guard e == event else { return self.identityMonad }
@@ -24,6 +33,10 @@ public class Reducer<State: Equatable, Event: Equatable> {
         graph.append(transition)
     }
 
+    /**
+     Reduce function.
+     This will combine all rules and produces a final lambda to decide the next state.
+     */
     public lazy var reduce: (State, Event) -> State = { [unowned self] state, event in
         let monad: StateMonad<State> = self.graph
             .map { $0(event) }

--- a/Sources/RxFeedback/Reducer.swift
+++ b/Sources/RxFeedback/Reducer.swift
@@ -42,9 +42,9 @@ public class Reducer<State: Equatable, Event: Equatable> {
             .map { $0(event) }
             .reduce(self.identityMonad) { lhs, rhs in
                 return StateMonad { s in
-                    if lhs.run(s: s) != state { return lhs.run(s: s) }
-                    if rhs.run(s: s) != state { return rhs.run(s: s) }
-                    return state
+                    if lhs.run(s: s) != s { return lhs.run(s: s) }
+                    if rhs.run(s: s) != s { return rhs.run(s: s) }
+                    return s
                 }
             }
         return monad.run(s: state)

--- a/Sources/RxFeedback/Reducer.swift
+++ b/Sources/RxFeedback/Reducer.swift
@@ -1,0 +1,48 @@
+//
+//  Reducer.swift
+//  RxFeedback
+//
+//  Created by DTVD on 11/4/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+class Reducer<State: Equatable, Event> {
+
+    typealias Transition = (Event) -> StateMonad<State>
+    private var graph: [Transition] = []
+    private let identity: State
+    private let identityMonad: StateMonad<State> = StateMonad { s in return s }
+    
+    init(defaultState: State) {
+        identity = defaultState
+    }
+
+    func addEdge(input: State, output: State, event: Event) {
+        let transition: Transition = { [unowned self] event in
+            return StateMonad { s in
+                let s1: State = s == input ? output : self.identity
+                return s1
+            }
+        }
+        graph.append(transition)
+    }
+
+    var reduce: Transition {
+        return { [unowned self] e in
+            return self.graph
+                .map { $0(e) }
+                .reduce(self.identityMonad) { lhs, rhs in
+                    return StateMonad { [unowned self] s in
+                        if lhs.run(s: s) != self.identity { return lhs.run(s: s) }
+                        if rhs.run(s: s) != self.identity { return rhs.run(s: s) }
+                        return self.identity
+                    }
+                }
+        }
+    }
+
+}
+
+

--- a/Sources/RxFeedback/Reducer.swift
+++ b/Sources/RxFeedback/Reducer.swift
@@ -16,7 +16,7 @@ public class Reducer<State: Equatable, Event: Equatable> {
 
     public init() {}
 
-    public func addEdge(event: Event, transform: @escaping (State) -> State) {
+    public func accept(event: Event, transform: @escaping (State) -> State) {
         let transition: Transition = { [unowned self] e in
             guard e == event else { return self.identityMonad }
             return StateMonad(f: transform)

--- a/Sources/RxFeedback/Reducer.swift
+++ b/Sources/RxFeedback/Reducer.swift
@@ -8,18 +8,18 @@
 
 import Foundation
 
-class Reducer<State: Equatable, Event> {
+public class Reducer<State: Equatable, Event> {
 
     typealias Transition = (Event) -> StateMonad<State>
     private var graph: [Transition] = []
     private let identity: State
     private let identityMonad: StateMonad<State> = StateMonad { s in return s }
     
-    init(defaultState: State) {
+    public init(defaultState: State) {
         identity = defaultState
     }
 
-    func addEdge(input: State, output: State, event: Event) {
+    public func addEdge(input: State, output: State, event: Event) {
         let transition: Transition = { [unowned self] event in
             return StateMonad { s in
                 let s1: State = s == input ? output : self.identity
@@ -29,7 +29,7 @@ class Reducer<State: Equatable, Event> {
         graph.append(transition)
     }
 
-    var reduce: Transition {
+    private var transitionFunction: Transition {
         return { [unowned self] e in
             return self.graph
                 .map { $0(e) }
@@ -40,6 +40,12 @@ class Reducer<State: Equatable, Event> {
                         return self.identity
                     }
                 }
+        }
+    }
+
+    public var reduce: (State, Event) -> State {
+        return { [unowned self] state, event in
+            return self.transitionFunction(event).run(s: state)
         }
     }
 

--- a/Sources/RxFeedback/StateMonad.swift
+++ b/Sources/RxFeedback/StateMonad.swift
@@ -1,0 +1,22 @@
+//
+//  StateMonad.swift
+//  RxFeedback
+//
+//  Created by DTVD on 11/4/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+struct StateMonad<S> {
+    private let run: (S) -> (S)
+
+    init(f: @escaping (S) -> (S)) {
+        self.run = f
+    }
+
+    func run(s: S) -> (S) {
+        return self.run(s)
+    }
+
+}

--- a/Sources/RxFeedback/StateMonad.swift
+++ b/Sources/RxFeedback/StateMonad.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+/**
+    This is simplest form of State Monad.
+    This struct is basically a wrapper for a state transform function (s) -> s
+ */
 struct StateMonad<S> {
     private let run: (S) -> (S)
 


### PR DESCRIPTION
Hello guys, I have been thinking of improving the `reduce` function in case there is complexity in transition rules. Until now we have to write full length `switch` lines. 

If there are multiple rules for same event then `reduce` can be even harder to read:
```swift
func reduce(state: State, event: Event) -> State {
    switch event {
    case .event1: 
        switch state {
        case .state1: // ...
        case .state2: // ...
        // every other cases ...
        }
    }
    // every other cases ...
}
```


This PR attempts to provide a more flexible and readable way to define these kind of graphs. Basically the type of reduce `(S, E) -> S` can be rewritten as `(E) -> (S) -> S` or `(E) -> StateMonad[S]`. `Reducer` instance will accept each individual rule and later combines them all to produce a final lambda.

```swift
let reducer = Reducer<State, Event>()
reducer.accept(.event1) { state in // Modify current state and return new state }
reducer.accept(.event2) { state in //... }
reducer.accept(.event3) { state in //... }
```

This idea comes from my talk about [Monadic Automaton](https://speakerdeck.com/dtvd/mercari-atte-and-automaton).