### PR TITLE
Replace the scheduledFeedback parameter with the feedback parameter

### DIFF
--- a/Examples/Counter.swift
+++ b/Examples/Counter.swift
@@ -38,7 +38,7 @@ class CounterViewController: UIViewController {
                 }
         },
             scheduler: MainScheduler.instance,
-            scheduledFeedback:
+            feedback:
                 // UI is user feedback
                 bind(self) { me, state -> Bindings<Event> in
                     let subscriptions = [

--- a/Examples/PlayCatch.swift
+++ b/Examples/PlayCatch.swift
@@ -55,7 +55,7 @@ class PlayCatchViewController: UIViewController {
                 }
         },
             scheduler: MainScheduler.instance,
-            scheduledFeedback:
+            feedback:
                 // UI is human feedback
                 bindUI,
                 // NoUI, machine feedback

--- a/Sources/RxFeedback/Deprecations.swift
+++ b/Sources/RxFeedback/Deprecations.swift
@@ -95,7 +95,7 @@ extension ObservableType where E == Any {
                 initialState: initialState,
                 reduce: reduce,
                 scheduler: scheduler,
-                scheduledFeedback: observableFeedbacks
+                feedback: observableFeedbacks
             )
     }
 
@@ -257,7 +257,7 @@ extension SharedSequenceConvertibleType where E == Any, SharingStrategy == Drive
                 initialState: initialState,
                 reduce: reduce,
                 scheduler: SharingStrategy.scheduler,
-                scheduledFeedback: observableFeedbacks
+                feedback: observableFeedbacks
             )
             .asDriver(onErrorDriveWith: .empty())
     }

--- a/Sources/RxFeedback/ObservableType+RxFeedback.swift
+++ b/Sources/RxFeedback/ObservableType+RxFeedback.swift
@@ -29,14 +29,14 @@ extension ObservableType where E == Any {
             initialState: State,
             reduce: @escaping (State, Event) -> State,
             scheduler: ImmediateSchedulerType,
-            scheduledFeedback: [Feedback<State, Event>]
+            feedback: [Feedback<State, Event>]
         ) -> Observable<State> {
         return Observable<State>.deferred {
             let replaySubject = ReplaySubject<State>.create(bufferSize: 1)
 
             let asyncScheduler = scheduler.async
             
-            let events: Observable<Event> = Observable.merge(scheduledFeedback.map { feedback in
+            let events: Observable<Event> = Observable.merge(feedback.map { feedback in
                 let state = ObservableSchedulerContext(source: replaySubject.asObservable(), scheduler: asyncScheduler)
                 return feedback(state)
             })
@@ -60,9 +60,9 @@ extension ObservableType where E == Any {
             initialState: State,
             reduce: @escaping (State, Event) -> State,
             scheduler: ImmediateSchedulerType,
-            scheduledFeedback: Feedback<State, Event>...
+            feedback: Feedback<State, Event>...
         ) -> Observable<State> {
-        return system(initialState: initialState, reduce: reduce, scheduler: scheduler, scheduledFeedback: scheduledFeedback)
+        return system(initialState: initialState, reduce: reduce, scheduler: scheduler, feedback: feedback)
     }
 }
 
@@ -97,7 +97,7 @@ extension SharedSequenceConvertibleType where E == Any, SharingStrategy == Drive
                 initialState: initialState,
                 reduce: reduce,
                 scheduler: SharingStrategy.scheduler,
-                scheduledFeedback: observableFeedbacks
+                feedback: observableFeedbacks
             )
             .asDriver(onErrorDriveWith: .empty())
     }

--- a/Tests/RxFeedbackTests/ReactEquatableLoopsTests.swift
+++ b/Tests/RxFeedbackTests/ReactEquatableLoopsTests.swift
@@ -32,7 +32,7 @@ extension ReactEquatableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback
+            feedback: feedback
         )
 
         // Run
@@ -63,7 +63,7 @@ extension ReactEquatableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback, { _ in events.asObservable() }
+            feedback: feedback, { _ in events.asObservable() }
         )
 
         // Run
@@ -92,7 +92,7 @@ extension ReactEquatableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback
+            feedback: feedback
         )
 
         // Run
@@ -138,7 +138,7 @@ extension ReactEquatableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback1, feedback2
+            feedback: feedback1, feedback2
         )
 
         // Run
@@ -188,7 +188,7 @@ extension ReactEquatableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback1, feedback2
+            feedback: feedback1, feedback2
         )
 
         // Run

--- a/Tests/RxFeedbackTests/ReactHashableLoopsTests.swift
+++ b/Tests/RxFeedbackTests/ReactHashableLoopsTests.swift
@@ -32,7 +32,7 @@ extension ReactHashableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback
+            feedback: feedback
         )
 
         // Run
@@ -63,7 +63,7 @@ extension ReactHashableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback, { _ in events.asObservable() }
+            feedback: feedback, { _ in events.asObservable() }
         )
 
         // Run
@@ -92,7 +92,7 @@ extension ReactHashableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback
+            feedback: feedback
         )
 
         // Run
@@ -138,7 +138,7 @@ extension ReactHashableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback1, feedback2
+            feedback: feedback1, feedback2
         )
 
         // Run
@@ -188,7 +188,7 @@ extension ReactHashableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback1, feedback2
+            feedback: feedback1, feedback2
         )
 
         // Run
@@ -241,7 +241,7 @@ extension ReactHashableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: react(query: query, effects: effects),
+            feedback: react(query: query, effects: effects),
             { _ in initiator.asObservable() }
         )
 
@@ -311,7 +311,7 @@ extension ReactHashableLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: react(query: query, effects: effects),
+            feedback: react(query: query, effects: effects),
             { _ in initiator.asObservable() }
         )
 

--- a/Tests/RxFeedbackTests/ReactNonEquatableLoopsTests.swift
+++ b/Tests/RxFeedbackTests/ReactNonEquatableLoopsTests.swift
@@ -32,7 +32,7 @@ extension ReactNonNilLoopsTests {
                 return  oldState + append
             },
             scheduler: scheduler,
-            scheduledFeedback: feedback
+            feedback: feedback
         )
 
         // Run
@@ -63,7 +63,7 @@ extension ReactNonNilLoopsTests {
                 return  oldState + append
             },
             scheduler: scheduler,
-            scheduledFeedback: feedback, { _ in events.asObservable() }
+            feedback: feedback, { _ in events.asObservable() }
         )
 
         // Run
@@ -92,7 +92,7 @@ extension ReactNonNilLoopsTests {
                 return  oldState + append
             },
             scheduler: scheduler,
-            scheduledFeedback: feedback
+            feedback: feedback
         )
 
         // Run
@@ -138,7 +138,7 @@ extension ReactNonNilLoopsTests {
                 return  oldState + append
             },
             scheduler: scheduler,
-            scheduledFeedback: feedback1, feedback2
+            feedback: feedback1, feedback2
         )
 
         // Run
@@ -188,7 +188,7 @@ extension ReactNonNilLoopsTests {
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback1, feedback2
+            feedback: feedback1, feedback2
         )
         
         // Run

--- a/Tests/RxFeedbackTests/RxFeedbackObservableTests.swift
+++ b/Tests/RxFeedbackTests/RxFeedbackObservableTests.swift
@@ -18,13 +18,16 @@ class RxFeedbackObservableTests: RxTest {
 extension RxFeedbackObservableTests {
     func testEventsAreArrivingOnCorrectScheduler() {
         let scheduler = SerialDispatchQueueScheduler(qos: .userInitiated)
+        let feedbackLoop: (ObservableSchedulerContext<String>) -> Observable<String> = {
+            _ in .just("a")
+        }
         let system = Observable.system(
             initialState: "initial",
             reduce: { oldState, append in
                 return oldState + "_" + append
             },
             scheduler: scheduler,
-            scheduledFeedback: { _ in .just("a") })
+            feedback: feedbackLoop)
 
         let results = try! system
             .take(2)
@@ -40,13 +43,14 @@ extension RxFeedbackObservableTests {
     }
     
     func testInitial() {
+        let feedbackLoop: [(ObservableSchedulerContext<String>) -> Observable<String>] = []
         let system = Observable.system(
             initialState: "initial",
             reduce: { _, newState in
                 return newState
             },
             scheduler: MainScheduler.instance,
-            scheduledFeedback: [])
+            feedback: feedbackLoop)
 
         var state = ""
         _ = system.subscribe(onNext: { nextState in
@@ -63,7 +67,7 @@ extension RxFeedbackObservableTests {
                 return  oldState + append
         },
             scheduler: MainScheduler.instance,
-            scheduledFeedback: { stateAndScheduler in
+            feedback: { (stateAndScheduler: ObservableSchedulerContext<String>) in
                 return stateAndScheduler.flatMap { state -> Observable<String> in
                     if state == "initial" {
                         return Observable.just("_a").delay(0.01, scheduler: MainScheduler.instance)
@@ -120,7 +124,7 @@ extension RxFeedbackObservableTests {
                 return  oldState + append
         },
             scheduler: MainScheduler.instance,
-            scheduledFeedback: feedbackLoop, feedbackLoop, feedbackLoop)
+            feedback: feedbackLoop, feedbackLoop, feedbackLoop)
 
         let result = (try?
             system
@@ -155,7 +159,7 @@ extension RxFeedbackObservableTests {
                 return  oldState + append
         },
             scheduler: MainScheduler.instance,
-            scheduledFeedback: feedbackLoop, feedbackLoop, feedbackLoop)
+            feedback: feedbackLoop, feedbackLoop, feedbackLoop)
 
         let result = (try?
             system
@@ -184,7 +188,7 @@ extension RxFeedbackObservableTests {
                 return  oldState + append
         },
             scheduler: MainScheduler.instance,
-            scheduledFeedback: feedbackLoop, feedbackLoop, feedbackLoop)
+            feedback: feedbackLoop, feedbackLoop, feedbackLoop)
 
         let result = (try?
             system
@@ -213,7 +217,7 @@ extension RxFeedbackObservableTests {
                 return  oldState + append
         },
             scheduler: MainScheduler.instance,
-            scheduledFeedback: feedbackLoop, feedbackLoop, feedbackLoop)
+            feedback: feedbackLoop, feedbackLoop, feedbackLoop)
 
         let result = (try?
             system
@@ -254,7 +258,7 @@ extension RxFeedbackObservableTests {
                 return  oldState + append
             },
             scheduler: MainScheduler.instance,
-            scheduledFeedback: RxFeedback.bind { (stateAndScheduler) in
+            feedback: RxFeedback.bind { (stateAndScheduler) in
                 let results = stateAndScheduler.flatMap { state -> Observable<String> in
                     if state == "initial" {
                         return Observable.just("_a").delay(0.01, scheduler: MainScheduler.instance)
@@ -297,7 +301,7 @@ extension RxFeedbackObservableTests {
                 return  oldState + append
             },
             scheduler: MainScheduler.instance,
-            scheduledFeedback: RxFeedback.bind(owner) { (_, stateAndScheduler) in
+            feedback: RxFeedback.bind(owner) { (_, stateAndScheduler) in
                 let results = stateAndScheduler.flatMap { state -> Observable<String> in
                     if state == "initial" {
                         return Observable.just("_a").delay(0.01, scheduler: MainScheduler.instance)


### PR DESCRIPTION
Hi guys,

- Replace the `scheduledFeedback` parameter with the `feedback` parameter for the `ObservableType` to be consistent with the current in the docs and in the one used for the `SharedSequenceConvertibleType`
- Update the examples regarding the rename of `scheduledFeedback`

I think is worth it as for me it caused some confusion when I went to use `Observable.system` and I noticed we don't have the expected `feedback`. Even in the examples, we have in the README we have the examples using `Observable.system` with the `feedback` parameter instead of the `scheduledFeedback`. In that way, we can unify that parameter. 