### PR TITLE
CircleCI migration process

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  xcode:
+    version: 9.2.0
+  environment:
+    LANG: en_US.UTF-8
+
+dependencies:
+  override:
+
+test:
+  pre:
+    - set -o pipefail
+  override:
+    


### PR DESCRIPTION
Hi guys, 

I listed here a list of steps to add to the configuration file, please edit the body if you think we need more steps to add. I added a default almost empty `circle.yml` to start adding steps according to the `.travis.yml` we have right now:

- [ ] Add support for caching Carthage reducing the build times considerably.
- [ ] Add support for Slack notifications
- [ ] Restrict the CI to only build on PR (This can be set in the project settings in CircleCI @kzaher )
- [ ] Add the shield badge for the build from CircleCI
