### PR TITLE
Fix immediate disposal of bindings when no long-lived event stream is specified.

### DIFF
--- a/Sources/RxFeedback/Feedbacks.swift
+++ b/Sources/RxFeedback/Feedbacks.swift
@@ -317,7 +317,7 @@ public func bind<State, Event>(_ bindings: @escaping (ObservableSchedulerContext
         return Observable<Event>.using({ () -> Bindings<Event> in
             return bindings(state)
         }, observableFactory: { (bindings: Bindings<Event>) -> Observable<Event> in
-            return Observable<Event>.merge(bindings.events)
+            return Observable<Event>.merge(bindings.events).concat(Observable.never())
                 .enqueue(state.scheduler)
         })
     }
@@ -340,7 +340,7 @@ public func bind<State, Event>(_ bindings: @escaping (Driver<State>) -> (Binding
         return Observable<Event>.using({ () -> Bindings<Event> in
             return bindings(state)
         }, observableFactory: { (bindings: Bindings<Event>) -> Observable<Event> in
-            return Observable<Event>.merge(bindings.events)
+            return Observable<Event>.merge(bindings.events).concat(Observable.never())
         })
             .enqueue(Signal<Event>.SharingStrategy.scheduler)
             .asSignal(onErrorSignalWith: .empty())


### PR DESCRIPTION
This fixes the case of immediate disposal of Bindings when not supplying an event stream but relying on other effects to create events.