### PR TITLE
Rename `Event` to `Mutation`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ playground.xcworkspace
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
-# Pods/
+Pods/
 
 # Carthage
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+- Rename `Event` to `Mutation`.
+
 ## [1.0.2](https://github.com/kzaher/RxFeedback/releases/tag/1.0.3)
 
 * Fixes problem with feedback loop termination.

--- a/Examples/Counter.swift
+++ b/Examples/Counter.swift
@@ -22,15 +22,16 @@ class CounterViewController: UIViewController {
         super.viewDidLoad()
 
         typealias State = Int
-        enum Event {
+
+        enum Mutation {
             case increment
             case decrement
         }
 
         Observable.system(
             initialState: 0,
-            reduce: { (state, event) -> State in
-                switch event {
+            reduce: { (state, mutation) -> State in
+                switch mutation {
                 case .increment:
                     return state + 1
                 case .decrement:
@@ -40,15 +41,18 @@ class CounterViewController: UIViewController {
             scheduler: MainScheduler.instance,
             scheduledFeedback:
                 // UI is user feedback
-                bind(self) { me, state -> Bindings<Event> in
+                bind(self) { me, state -> Bindings<Mutation> in
                     let subscriptions = [
                         state.map(String.init).bind(to: me.label!.rx.text)
                     ]
-                    let events = [
-                        me.plus!.rx.tap.map { Event.increment },
-                        me.minus!.rx.tap.map { Event.decrement }
+
+                    let mutations = [
+                        me.plus!.rx.tap.map { Mutation.increment },
+                        me.minus!.rx.tap.map { Mutation.decrement }
                     ]
-                    return Bindings(subscriptions: subscriptions, events: events)
+
+                    return Bindings(subscriptions: subscriptions,
+                                    mutations: mutations)
                 }
             )
             .subscribe()

--- a/Examples/Todo+Feedback.swift
+++ b/Examples/Todo+Feedback.swift
@@ -12,16 +12,17 @@ import RxCocoa
 import RxFeedback
 
 extension Todo {
-    typealias Feedback = (Driver<Todo>) -> Signal<Todo.Event>
+    typealias Feedback = (Driver<Todo>) -> Signal<Todo.Mutation>
     
     static func system(initialState: Todo,
                        ui: @escaping Feedback,
                        synchronizeTask: @escaping (Task) -> Single<SyncState>) -> Driver<Todo> {
 
-        let synchronizeFeedback: Feedback = react(query: { $0.tasksToSynchronize }) { task -> Signal<Todo.Event> in
+        let synchronizeFeedback: Feedback = react(query: { $0.tasksToSynchronize }) { task -> Signal<Todo.Mutation> in
             return synchronizeTask(task.value)
-                .map { Todo.Event.synchronizationChanged(task, $0) }
-                .asSignal(onErrorRecover: { error in Signal.just(.synchronizationChanged(task, .failed(error))) })
+                .map { Todo.Mutation.synchronizationChanged(task, $0) }
+                .asSignal(onErrorRecover: { error in Signal.just(.synchronizationChanged(task, .failed(error)))
+                })
         }
 
         return Driver<Any>.system(initialState: initialState,

--- a/Examples/Todo.swift
+++ b/Examples/Todo.swift
@@ -29,7 +29,7 @@ struct Task {
 }
 
 struct Todo {
-    enum Event {
+    enum Mutation {
         case created(Version<Task>)
         case toggleCompleted(Version<Task>)
         case archive(Version<Task>)
@@ -45,8 +45,8 @@ struct Todo {
 }
 
 extension Todo {
-    static func reduce(state: Todo, event: Event) -> Todo {
-        switch event {
+    static func reduce(state: Todo, mutation: Mutation) -> Todo {
+        switch mutation {
         case .created(let task):
             return state.map(task: task, transform: Version<Task>.mutate { _ in })
         case .toggleCompleted(let task):
@@ -63,7 +63,9 @@ extension Todo {
 
 extension Todo {
     static func `for`(tasks: [Task]) -> Todo {
-        return tasks.reduce(Todo()) { (all, task) in Todo.reduce(state: all, event: .created(Version(task)))  }
+        return tasks.reduce(Todo()) { (all, task) in
+            Todo.reduce(state: all, mutation: .created(Version(task)))
+        }
     }
 }
 

--- a/RxFeedback.podspec
+++ b/RxFeedback.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
         * =>  It's just state + CQRS
     * Straightforward
         * if it's state -> State
-        * if it's a way to modify state -> Event/Command
+        * if it's a way to modify state -> Mutation
         * it it's an effect -> encode it into part of state and then design a feedback loop
     * Declarative
         * System behavior is first declaratively specified and effects begin after subscribe is called => Compile time proof there are no "unhandled states"

--- a/Sources/RxFeedback/Deprecations.swift
+++ b/Sources/RxFeedback/Deprecations.swift
@@ -24,10 +24,10 @@ import RxCocoa
  - returns: Feedback loop performing the effects.
  */
 @available(*, deprecated, message: "Renamed to version that takes `ObservableSchedulerContext` as argument.", renamed: "react(query:effects:)")
-public func react<State, Control: Equatable, Event>(
+public func react<State, Control: Equatable, Mutation>(
     query: @escaping (State) -> Control?,
-    effects: @escaping (Control) -> Observable<Event>
-) -> (Observable<State>) -> Observable<Event> {
+    effects: @escaping (Control) -> Observable<Mutation>
+) -> (Observable<State>) -> Observable<Mutation> {
     return { state in
         let context = ObservableSchedulerContext(source: state, scheduler: CurrentThreadScheduler.instance)
         return react(query: query, effects: effects)(context)
@@ -49,10 +49,10 @@ public func react<State, Control: Equatable, Event>(
  - returns: Feedback loop performing the effects.
  */
 @available(*, deprecated, message: "Renamed to version that takes `ObservableSchedulerContext` as argument.", renamed: "react(query:effects:)")
-public func react<State, Control, Event>(
+public func react<State, Control, Mutation>(
     query: @escaping (State) -> Control?,
-    effects: @escaping (Control) -> Observable<Event>
-    ) -> (Observable<State>) -> Observable<Event> {
+    effects: @escaping (Control) -> Observable<Mutation>
+    ) -> (Observable<State>) -> Observable<Mutation> {
     return { state in
         let context = ObservableSchedulerContext(source: state, scheduler: CurrentThreadScheduler.instance)
         return react(query: query, effects: effects)(context)
@@ -71,21 +71,21 @@ extension ObservableType where E == Any {
      System simulation will be started upon subscription and stopped after subscription is disposed.
 
      System state is represented as a `State` parameter.
-     Events are represented by `Event` parameter.
+     Mutations are represented by `Mutation` parameter.
 
      - parameter initialState: Initial state of the system.
-     - parameter accumulator: Calculates new system state from existing state and a transition event (system integrator, reducer).
-     - parameter feedback: Feedback loops that produce events depending on current system state.
+     - parameter accumulator: Calculates new system state from existing state and a transition mutation (system integrator, reducer).
+     - parameter feedback: Feedback loops that produce mutations depending on current system state.
      - returns: Current state of the system.
      */
     @available(*, deprecated, message: "Renamed to version that takes `ObservableSchedulerContext` as argument.", renamed: "system(initialState:reduce:scheduler:scheduledFeedback:)")
-    public static func system<State, Event>(
+    public static func system<State, Mutation>(
         initialState: State,
-        reduce: @escaping (State, Event) -> State,
+        reduce: @escaping (State, Mutation) -> State,
         scheduler: ImmediateSchedulerType,
-        feedback: [(Observable<State>) -> Observable<Event>]
+        feedback: [(Observable<State>) -> Observable<Mutation>]
         ) -> Observable<State> {
-        let observableFeedbacks: [(ObservableSchedulerContext<State>) -> Observable<Event>] = feedback.map { feedback in
+        let observableFeedbacks: [(ObservableSchedulerContext<State>) -> Observable<Mutation>] = feedback.map { feedback in
             return { sourceSchedulerContext in
                 return feedback(sourceSchedulerContext.source)
             }
@@ -100,11 +100,11 @@ extension ObservableType where E == Any {
     }
 
     @available(*, deprecated, message: "Renamed to version that takes `ObservableSchedulerContext` as argument.", renamed: "system(initialState:reduce:scheduler:scheduledFeedback:)")
-    public static func system<State, Event>(
+    public static func system<State, Mutation>(
         initialState: State,
-        reduce: @escaping (State, Event) -> State,
+        reduce: @escaping (State, Mutation) -> State,
         scheduler: ImmediateSchedulerType,
-        feedback: (Observable<State>) -> Observable<Event>...
+        feedback: (Observable<State>) -> Observable<Mutation>...
     ) -> Observable<State> {
         return system(initialState: initialState, reduce: reduce, scheduler: scheduler, feedback: feedback)
     }
@@ -124,17 +124,17 @@ extension ObservableType where E == Any {
  - parameter effects: Control state which is subset of state.
  - returns: Feedback loop performing the effects.
  */
-@available(*, deprecated, message: "Please use version that uses feedback with this signature `Driver<State> -> Signal<Event>`")
-public func react<State, Control: Equatable, Event>(
+@available(*, deprecated, message: "Please use version that uses feedback with this signature `Driver<State> -> Signal<Mutation>`")
+public func react<State, Control: Equatable, Mutation>(
     query: @escaping (State) -> Control?,
-    effects: @escaping (Control) -> Driver<Event>
-) -> (Driver<State>) -> Driver<Event> {
+    effects: @escaping (Control) -> Driver<Mutation>
+) -> (Driver<State>) -> Driver<Mutation> {
     return { state in
         return state.map(query)
             .distinctUntilChanged { $0 == $1 }
-            .flatMapLatest { (control: Control?) -> Driver<Event> in
+            .flatMapLatest { (control: Control?) -> Driver<Mutation> in
                 guard let control = control else {
-                    return Driver<Event>.empty()
+                    return Driver<Mutation>.empty()
                 }
 
                 return effects(control)
@@ -157,17 +157,17 @@ public func react<State, Control: Equatable, Event>(
  - parameter effects: Control state which is subset of state.
  - returns: Feedback loop performing the effects.
  */
-@available(*, deprecated, message: "Please use version that uses feedback with this signature `Driver<State> -> Signal<Event>`")
-public func react<State, Control, Event>(
+@available(*, deprecated, message: "Please use version that uses feedback with this signature `Driver<State> -> Signal<Mutation>`")
+public func react<State, Control, Mutation>(
     query: @escaping (State) -> Control?,
-    effects: @escaping (Control) -> Driver<Event>
-) -> (Driver<State>) -> Driver<Event> {
+    effects: @escaping (Control) -> Driver<Mutation>
+) -> (Driver<State>) -> Driver<Mutation> {
     return { state in
         return state.map(query)
             .distinctUntilChanged { $0 != nil }
-            .flatMapLatest { (control: Control?) -> Driver<Event> in
+            .flatMapLatest { (control: Control?) -> Driver<Mutation> in
                 guard let control = control else {
-                    return Driver<Event>.empty()
+                    return Driver<Mutation>.empty()
                 }
 
                 return effects(control)
@@ -190,20 +190,20 @@ public func react<State, Control, Event>(
  - parameter effects: Control state which is subset of state.
  - returns: Feedback loop performing the effects.
  */
-@available(*, deprecated, message: "Please use version that uses feedback with this signature `Driver<State> -> Signal<Event>`")
-public func react<State, Control, Event>(
+@available(*, deprecated, message: "Please use version that uses feedback with this signature `Driver<State> -> Signal<Mutation>`")
+public func react<State, Control, Mutation>(
     query: @escaping (State) -> Set<Control>,
-    effects: @escaping (Control) -> Driver<Event>
-    ) -> (Driver<State>) -> Driver<Event> {
+    effects: @escaping (Control) -> Driver<Mutation>
+    ) -> (Driver<State>) -> Driver<Mutation> {
     return { state in
         let query = state.map(query)
 
         let newQueries = Driver.zip(query, query.startWith(Set())) { $0.subtracting($1) }
 
         return newQueries.flatMap { controls in
-            return Driver.merge(controls.map { control -> Driver<Event> in
+            return Driver.merge(controls.map { control -> Driver<Mutation> in
                 return query.filter { !$0.contains(control) }
-                    .map { _ in Driver<Event>.empty() }
+                    .map { _ in Driver<Mutation>.empty() }
                     .startWith(effects(control).enqueue())
                     .switchLatest()
             })
@@ -227,26 +227,26 @@ extension SharedSequence where SharingStrategy == DriverSharingStrategy {
 extension SharedSequenceConvertibleType where E == Any, SharingStrategy == DriverSharingStrategy {
     /// Feedback loop
     @available(*, deprecated, message: "Please use Feedback")
-    public typealias FeedbackLoop<State, Event> = (Driver<State>) -> Driver<Event>
+    public typealias FeedbackLoop<State, Mutation> = (Driver<State>) -> Driver<Mutation>
 
     /**
      System simulation will be started upon subscription and stopped after subscription is disposed.
 
      System state is represented as a `State` parameter.
-     Events are represented by `Event` parameter.
+     Mutations are represented by `Mutation` parameter.
 
      - parameter initialState: Initial state of the system.
-     - parameter accumulator: Calculates new system state from existing state and a transition event (system integrator, reducer).
-     - parameter feedback: Feedback loops that produce events depending on current system state.
+     - parameter accumulator: Calculates new system state from existing state and a transition mutation (system integrator, reducer).
+     - parameter feedback: Feedback loops that produce mutations depending on current system state.
      - returns: Current state of the system.
      */
-    @available(*, deprecated, message: "Please use version that uses feedbacks with this signature `Driver<State> -> Signal<Event>`")
-    public static func system<State, Event>(
+    @available(*, deprecated, message: "Please use version that uses feedbacks with this signature `Driver<State> -> Signal<Mutation>`")
+    public static func system<State, Mutation>(
             initialState: State,
-            reduce: @escaping (State, Event) -> State,
-            feedback: [FeedbackLoop<State, Event>]
+            reduce: @escaping (State, Mutation) -> State,
+            feedback: [FeedbackLoop<State, Mutation>]
         ) -> Driver<State> {
-        let observableFeedbacks: [(ObservableSchedulerContext<State>) -> Observable<Event>] = feedback.map { feedback in
+        let observableFeedbacks: [(ObservableSchedulerContext<State>) -> Observable<Mutation>] = feedback.map { feedback in
             return { sharedSequence in
                 return feedback(sharedSequence.source.asDriver(onErrorDriveWith: Driver<State>.empty()))
                     .asObservable()
@@ -262,11 +262,11 @@ extension SharedSequenceConvertibleType where E == Any, SharingStrategy == Drive
             .asDriver(onErrorDriveWith: .empty())
     }
 
-    @available(*, deprecated, message: "Please use version that uses feedback with this signature `Driver<State> -> Signal<Event>`")
-    public static func system<State, Event>(
+    @available(*, deprecated, message: "Please use version that uses feedback with this signature `Driver<State> -> Signal<Mutation>`")
+    public static func system<State, Mutation>(
             initialState: State,
-            reduce: @escaping (State, Event) -> State,
-            feedback: FeedbackLoop<State, Event>...
+            reduce: @escaping (State, Mutation) -> State,
+            feedback: FeedbackLoop<State, Mutation>...
         ) -> Driver<State> {
         return system(initialState: initialState, reduce: reduce, feedback: feedback)
     }
@@ -275,32 +275,32 @@ extension SharedSequenceConvertibleType where E == Any, SharingStrategy == Drive
 @available(*, deprecated, message: "Please use free members from RxFeedback module (`RxFeedback.Bindings`, `RxFeedback.bind`, ...).")
 public struct UI {
     /**
-     Contains subscriptions and events.
+     Contains subscriptions and mutations.
      - `subscriptions` map a system state to UI presentation.
-     - `events` map events from UI to events of a given system.
+     - `mutations` map mutations from UI to mutations of a given system.
     */
-    public class Bindings<Event>: Disposable {
+    public class Bindings<Mutation>: Disposable {
         fileprivate let subscriptions: [Disposable]
-        fileprivate let events: [Observable<Event>]
+        fileprivate let mutations: [Observable<Mutation>]
 
         /**
          - parameters:
             - subscriptions: mappings of a system state to UI presentation.
-            - events: mappings of events from UI to events of a given system
+            - mutations: mappings of mutations from UI to mutations of a given system
          */
-        public init(subscriptions: [Disposable], events: [Observable<Event>]) {
+        public init(subscriptions: [Disposable], mutations: [Observable<Mutation>]) {
             self.subscriptions = subscriptions
-            self.events = events
+            self.mutations = mutations
         }
 
         /**
          - parameters:
             - subscriptions: mappings of a system state to UI presentation.
-            - events: mappings of events from UI to events of a given system
+            - mutations: mappings of mutations from UI to mutations of a given system
          */
-        public init(subscriptions: [Disposable], events: [Driver<Event>]) {
+        public init(subscriptions: [Disposable], mutations: [Driver<Mutation>]) {
             self.subscriptions = subscriptions
-            self.events = events.map { $0.asObservable() }
+            self.mutations = mutations.map { $0.asObservable() }
         }
 
         public func dispose() {
@@ -311,58 +311,59 @@ public struct UI {
     }
 
     /**
-     Bi-directional binding of a system State to UI and UI into Events.
+     Bi-directional binding of a system State to UI and UI into Mutations.
      */
-    public static func bind<State, Event>(_ bindings: @escaping (ObservableSchedulerContext<State>) -> (Bindings<Event>)) -> (ObservableSchedulerContext<State>) -> Observable<Event> {
+    public static func bind<State, Mutation>(_ bindings: @escaping (ObservableSchedulerContext<State>) -> (Bindings<Mutation>)) -> (ObservableSchedulerContext<State>) -> Observable<Mutation> {
 
-        return { (state: ObservableSchedulerContext<State>) -> Observable<Event> in
-            return Observable<Event>.using({ () -> Bindings<Event> in
+        return { (state: ObservableSchedulerContext<State>) -> Observable<Mutation> in
+            return Observable<Mutation>.using({ () -> Bindings<Mutation> in
                 return bindings(state)
-            }, observableFactory: { (bindings: Bindings<Event>) -> Observable<Event> in
-                return Observable<Event>.merge(bindings.events)
-                    .enqueue(state.scheduler)
+            }, observableFactory: { (bindings: Bindings<Mutation>) -> Observable<Mutation> in
+                return Observable<Mutation>
+                        .merge(bindings.mutations)
+                        .enqueue(state.scheduler)
             })
         }
     }
 
     /**
-     Bi-directional binding of a system State to UI and UI into Events,
+     Bi-directional binding of a system State to UI and UI into Mutations,
      Strongify owner.
      */
-    public static func bind<State, Event, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping (WeakOwner, ObservableSchedulerContext<State>) -> (Bindings<Event>))
-        -> (ObservableSchedulerContext<State>) -> Observable<Event> where WeakOwner: AnyObject {
+    public static func bind<State, Mutation, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping (WeakOwner, ObservableSchedulerContext<State>) -> (Bindings<Mutation>))
+        -> (ObservableSchedulerContext<State>) -> Observable<Mutation> where WeakOwner: AnyObject {
             return bind(bindingsStrongify(owner, bindings))
     }
 
     /**
-     Bi-directional binding of a system State to UI and UI into Events.
+     Bi-directional binding of a system State to UI and UI into Mutations.
      */
-    public static func bind<State, Event>(_ bindings: @escaping (Driver<State>) -> (Bindings<Event>)) -> (Driver<State>) -> Driver<Event> {
+    public static func bind<State, Mutation>(_ bindings: @escaping (Driver<State>) -> (Bindings<Mutation>)) -> (Driver<State>) -> Driver<Mutation> {
 
-        return { (state: Driver<State>) -> Driver<Event> in
-            return Observable<Event>.using({ () -> Bindings<Event> in
+        return { (state: Driver<State>) -> Driver<Mutation> in
+            return Observable<Mutation>.using({ () -> Bindings<Mutation> in
                 return bindings(state)
-            }, observableFactory: { (bindings: Bindings<Event>) -> Observable<Event> in
-                return Observable<Event>.merge(bindings.events)
+            }, observableFactory: { (bindings: Bindings<Mutation>) -> Observable<Mutation> in
+                return Observable<Mutation>.merge(bindings.mutations)
             }).asDriver(onErrorDriveWith: Driver.empty())
                 .enqueue()
         }
     }
 
     /**
-     Bi-directional binding of a system State to UI and UI into Events,
+     Bi-directional binding of a system State to UI and UI into Mutations,
      Strongify owner.
      */
-    public static func bind<State, Event, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping (WeakOwner, Driver<State>) -> (Bindings<Event>))
-        -> (Driver<State>) -> Driver<Event> where WeakOwner: AnyObject {
+    public static func bind<State, Mutation, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping (WeakOwner, Driver<State>) -> (Bindings<Mutation>))
+        -> (Driver<State>) -> Driver<Mutation> where WeakOwner: AnyObject {
             return bind(bindingsStrongify(owner, bindings))
     }
 
-    private static func bindingsStrongify<Event, O, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping (WeakOwner, O) -> (Bindings<Event>))
-        -> (O) -> (Bindings<Event>) where WeakOwner: AnyObject {
-            return { [weak owner] state -> Bindings<Event> in
+    private static func bindingsStrongify<Mutation, O, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping (WeakOwner, O) -> (Bindings<Mutation>))
+        -> (O) -> (Bindings<Mutation>) where WeakOwner: AnyObject {
+            return { [weak owner] state -> Bindings<Mutation> in
                 guard let strongOwner = owner else {
-                    return Bindings(subscriptions: [], events: [Observable<Event>]())
+                    return Bindings(subscriptions: [], mutations: [Observable<Mutation>]())
                 }
                 return bindings(strongOwner, state)
             }

--- a/Sources/RxFeedback/Deprecations.swift
+++ b/Sources/RxFeedback/Deprecations.swift
@@ -272,6 +272,18 @@ extension SharedSequenceConvertibleType where E == Any, SharingStrategy == Drive
     }
 }
 
+public extension Bindings {
+    @available(*, deprecated, message: "Please use Bindings(subscriptions:mutations:) instead.")
+    convenience init(subscriptions: [Disposable], events: [Observable<Mutation>]) {
+        self.init(subscriptions: subscriptions, mutations: events)
+    }
+
+    @available(*, deprecated, message: "Please use Bindings(subscriptions:mutations:) instead.")
+    convenience init(subscriptions: [Disposable], events: [Signal<Mutation>]) {
+        self.init(subscriptions: subscriptions, mutations: events)
+    }
+}
+
 @available(*, deprecated, message: "Please use free members from RxFeedback module (`RxFeedback.Bindings`, `RxFeedback.bind`, ...).")
 public struct UI {
     /**

--- a/Tests/RxFeedbackTests/ReactEquatableLoopsTests.swift
+++ b/Tests/RxFeedbackTests/ReactEquatableLoopsTests.swift
@@ -56,18 +56,18 @@ extension ReactEquatableLoopsTests {
         }
         let effects: (String) -> Observable<String> = { .just($0 + "_a") }
         let feedback: (ObservableSchedulerContext<String>) -> Observable<String> = react(query: query, effects: effects)
-        let events = PublishSubject<String>()
+        let mutations = PublishSubject<String>()
         let system = Observable.system(
             initialState: "initial",
             reduce: { oldState, append in
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback, { _ in events.asObservable() }
+            scheduledFeedback: feedback, { _ in mutations.asObservable() }
         )
 
         // Run
-        scheduler.scheduleAt(210) { events.onNext("+") }
+        scheduler.scheduleAt(210) { mutations.onNext("+") }
         let results = scheduler.start { system }
 
         // Test

--- a/Tests/RxFeedbackTests/ReactHashableLoopsTests.swift
+++ b/Tests/RxFeedbackTests/ReactHashableLoopsTests.swift
@@ -56,18 +56,18 @@ extension ReactHashableLoopsTests {
         }
         let effects: (String) -> Observable<String> = { .just($0 + "_a") }
         let feedback: (ObservableSchedulerContext<String>) -> Observable<String> = react(query: query, effects: effects)
-        let events = PublishSubject<String>()
+        let mutations = PublishSubject<String>()
         let system = Observable.system(
             initialState: "initial",
             reduce: { oldState, append in
                 return  oldState + append
         },
             scheduler: scheduler,
-            scheduledFeedback: feedback, { _ in events.asObservable() }
+            scheduledFeedback: feedback, { _ in mutations.asObservable() }
         )
 
         // Run
-        scheduler.scheduleAt(210) { events.onNext("+") }
+        scheduler.scheduleAt(210) { mutations.onNext("+") }
         let results = scheduler.start { system }
 
         // Test

--- a/Tests/RxFeedbackTests/ReactNonEquatableLoopsTests.swift
+++ b/Tests/RxFeedbackTests/ReactNonEquatableLoopsTests.swift
@@ -56,18 +56,18 @@ extension ReactNonNilLoopsTests {
         }
         let effects: () -> Observable<String> = { .just("_a") }
         let feedback: (ObservableSchedulerContext<String>) -> Observable<String> = react(query: query, effects: effects)
-        let events = PublishSubject<String>()
+        let mutations = PublishSubject<String>()
         let system = Observable.system(
             initialState: "initial",
             reduce: { oldState, append in
                 return  oldState + append
             },
             scheduler: scheduler,
-            scheduledFeedback: feedback, { _ in events.asObservable() }
+            scheduledFeedback: feedback, { _ in mutations.asObservable() }
         )
 
         // Run
-        scheduler.scheduleAt(210) { events.onNext("+") }
+        scheduler.scheduleAt(210) { mutations.onNext("+") }
         let results = scheduler.start { system }
 
         // Test

--- a/Tests/RxFeedbackTests/RxFeedbackDriverTests.swift
+++ b/Tests/RxFeedbackTests/RxFeedbackDriverTests.swift
@@ -241,7 +241,8 @@ extension RxFeedbackDriverTests {
                         return Signal.never()
                     }
                 }
-                return Bindings(subscriptions: [], events: [results])
+
+                return Bindings(subscriptions: [], mutations: [results])
         })
 
         let result = (try?
@@ -284,7 +285,7 @@ extension RxFeedbackDriverTests {
                         return Signal.never()
                     }
                 }
-                return Bindings(subscriptions: [], events: [results])
+                return Bindings(subscriptions: [], mutations: [results])
             })
 
         let result = (try?
@@ -303,10 +304,10 @@ extension RxFeedbackDriverTests {
             "initial_a_b_c"
             ])
     }
-    func testBindingsAreNotDisposedWhenNoEventsAreSpecifiedOnDriverSystem() {
+    func testBindingsAreNotDisposedWhenNoMutationsAreSpecifiedOnDriverSystem() {
         typealias State = Int
-        typealias Event = Int
-        typealias Feedback = (Driver<State>) -> Signal<Event>
+        typealias Mutation = Int
+        typealias Feedback = (Driver<State>) -> Signal<Mutation>
 
         let testScheduler = TestScheduler(initialClock: 0)
         var testableObserver: TestableObserver<Int>!
@@ -327,12 +328,12 @@ extension RxFeedbackDriverTests {
                 let subscriptions: [Disposable] = [
                     state.drive(onNext:{ subscriptionState.append($0) })
                 ]
-                return Bindings(subscriptions: subscriptions, events: [Observable<Event>]())
+                return Bindings(subscriptions: subscriptions, mutations: [Observable<Mutation>]())
             }
             let system = Driver.system(
                 initialState: 0,
-                reduce: { oldState, event in
-                    return  oldState + event
+                reduce: { oldState, mutation in
+                    return oldState + mutation
                 },
                 feedback: mockUIBindings, player
             )

--- a/Tests/RxFeedbackTests/RxFeedbackObservableTests.swift
+++ b/Tests/RxFeedbackTests/RxFeedbackObservableTests.swift
@@ -17,7 +17,7 @@ class RxFeedbackObservableTests: RxTest {
 }
 
 extension RxFeedbackObservableTests {
-    func testEventsAreArrivingOnCorrectScheduler() {
+    func testMutationsAreArrivingOnCorrectScheduler() {
         let scheduler = SerialDispatchQueueScheduler(qos: .userInitiated)
         let system = Observable.system(
             initialState: "initial",
@@ -270,7 +270,8 @@ extension RxFeedbackObservableTests {
                         return Observable.never()
                     }
                 }
-                return Bindings(subscriptions: [], events: [results])
+
+                return Bindings(subscriptions: [], mutations: [results])
         })
 
         let result = (try?
@@ -313,7 +314,8 @@ extension RxFeedbackObservableTests {
                         return Observable.never()
                     }
                 }
-                return Bindings(subscriptions: [], events: [results])
+
+                return Bindings(subscriptions: [], mutations: [results])
         })
 
         let result = (try?
@@ -332,10 +334,10 @@ extension RxFeedbackObservableTests {
             ])
     }
 
-    func testBindingsAreNotDisposedWhenNoEventsAreSpecifiedOnObservableSystem() {
+    func testBindingsAreNotDisposedWhenNoMutationsAreSpecifiedOnObservableSystem() {
         typealias State = Int
-        typealias Event = Int
-        typealias Feedback = (ObservableSchedulerContext<State>) -> Observable<Event>
+        typealias Mutation = Int
+        typealias Feedback = (ObservableSchedulerContext<State>) -> Observable<Mutation>
 
         let testScheduler = TestScheduler(initialClock: 0)
         let timer = testScheduler.createColdObservable([
@@ -355,12 +357,14 @@ extension RxFeedbackObservableTests {
                     .do(onDispose: { subscriptionIsDisposed = true })
                     .subscribe(onNext:{ subscriptionState.append($0) })
             ]
-            return Bindings(subscriptions: subscriptions, events: [Observable<Event>]())
+
+            return Bindings(subscriptions: subscriptions, mutations: [Observable<Mutation>]())
         }
+
         let system = Observable.system(
             initialState: 0,
-            reduce: { oldState, event in
-                return  oldState + event
+            reduce: { oldState, mutation in
+                return oldState + mutation
             },
             scheduler: testScheduler,
             scheduledFeedback: mockUIBindings, player


### PR DESCRIPTION
Per conversation in private with @kzaher, this PR renames `Event` to `Mutation` to make its purpose clearer.

It also deprecates the `Bindings(subscriptions:events:)` initializer. 